### PR TITLE
Allow to define additional authorized keys

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,6 @@ authorized_keys:
 private_keys:
 
 public_keys:
+
+additional_authorized_keys:
+  "{{ app_user }}": 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Add authorized keys for {{ app_user }}
   copy:
-    content: "{{ authorized_keys[app_user] }}"
+    content: "{{ authorized_keys[app_user] + additional_authorized_keys[app_user] }}"
     dest: "~{{ app_user }}/.ssh/authorized_keys"
     owner: "{{ app_user }}"
     group: "{{ app_user }}"


### PR DESCRIPTION
This is a change mainly made for infra provision, because we have certain hosts which have additional users which are allowed to connect to the butler user. This change was directly made in the infra provision repo, but it is cleaner to transfer the change into the ansible role.
