### PR TITLE
Add user to groups rather than overwriting all its groups

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Ensure group "www-data" exists
   group:
     name: "www-data"
@@ -10,6 +9,7 @@
     name: "{{ app_user }}"
     shell: "/bin/bash"
     groups: "www-data"
+    append: yes
 
 - name: "Create .ssh directory for {{ app_user }}"
   file:
@@ -45,4 +45,3 @@
     group: "{{ app_user }}"
     mode: 0600
   when: public_keys[app_user] is defined
-


### PR DESCRIPTION
When a provisioning failed, it could happen that the app_user was removed from groups which would be added later, because "append" in the user module is per default "no". By changing this to "yes", the user will be added to the mentioned group and will preserve all its other groups.